### PR TITLE
Fixed issue with running tests on vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 >>>>>>> main
+
+
+.vscode/**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,10 @@
 import pytest
+import sys, os
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
 import adventure_colussus.entities as ents
 from random import seed
 


### PR DESCRIPTION
This commit fixes import errors when running tests with Visual Studio Code by adding the root folder of the repository to the python path in conftest.py, removing __init__.py in the tests folder, and adding .vscode to the gitignore to prevent accidentally updating other collaborator's settings.

This is in response to discussion #61 